### PR TITLE
Upgrade to Webpack 5 to resolve vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7847,12 +7847,6 @@
       "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
       "dev": true
     },
-    "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
-    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -14781,12 +14775,6 @@
         "picomatch": "^2.0.5"
       }
     },
-    "mime": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
-      "dev": true
-    },
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
@@ -18116,50 +18104,6 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
-        }
-      }
-    },
-    "url-loader": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
-      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.0.2",
-        "mime": "1.3.x"
-      },
-      "dependencies": {
-        "big.js": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-          "dev": true
-        },
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "standard-version": "^9.0.0",
     "string-replace-loader": "^2.3.0",
     "style-loader": "^3.3.1",
-    "url-loader": "^0.5.9",
     "webpack": "^5.60.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.3.1"

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -64,9 +64,7 @@ module.exports = {
       use: ['style-loader', 'css-loader']
     }, {
       test: /\.(jpg|png|gif|svg|woff|ttf|eot)$/,
-      use: {
-        loader: 'url-loader'
-      }
+      type: 'asset/inline'
     },
   ]
   },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -58,9 +58,7 @@ module.exports = [{
       },
       {
         test: /\.(jpg|png|gif|svg|woff|ttf|eot)$/,
-        use: {
-          loader: 'url-loader'
-        }
+        type: 'asset/inline'
       }
     ]
   },
@@ -133,9 +131,7 @@ module.exports = [{
       },
       {
         test: /\.(jpg|png|gif|svg|woff|ttf|eot)$/,
-        use: {
-          loader: 'url-loader'
-        }
+        type: 'asset/inline'
       }
     ]
   },


### PR DESCRIPTION
**Proposed changes**:
- Updated Webpack to the v5.6  
   - Webpack 5 no longer includes automatic polyfills so `path-browserify` was added [to resolve the issue with path](https://github.com/webpack/webpack/issues/11600). 
- Updated the following build related dependencies to the latest versions:
   - `webpack-cli`
   - `html-webpack-plugin` (to resolve `TypeError: Cannot add property htmlWebpackPluginAlterChunks`)
   - `css-loader`
   - `style-loader`
- `url-loader` was removed and replaced with [Webpack 5 asset module](https://webpack.js.org/guides/asset-modules/) as recommended  in [upgrade guide to Webpack 5](https://webpack.js.org/migrate/5/#clean-up-configuration)
- Error where `process` was undefined (as Webpack 5 no longer provides it polyfill by default) was solved [by shimming the process](https://github.com/vfile/vfile/issues/38#issuecomment-640479137). 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
